### PR TITLE
ci: pin Windows release build to MSVC

### DIFF
--- a/.github/workflows/cli-matrix.yml
+++ b/.github/workflows/cli-matrix.yml
@@ -312,7 +312,9 @@ jobs:
             echo QTDIR is not set.
             exit /b 1
           )
-          cmake ${{ steps.vcpkg.outputs.vcpkg-cmake-config }} -B build -S %GITHUB_WORKSPACE% -DCMAKE_INSTALL_PREFIX=%GITHUB_WORKSPACE%\${{ matrix.install_prefix }} -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=%QTDIR% -DGDL_UI_GENERATE_TRANSLATIONS=on -GNinja -DCMAKE_CXX_FLAGS="-D_WIN32_WINNT=0x0A00"
+          set "CC=cl"
+          set "CXX=cl"
+          cmake ${{ steps.vcpkg.outputs.vcpkg-cmake-config }} -B build -S %GITHUB_WORKSPACE% -DCMAKE_INSTALL_PREFIX=%GITHUB_WORKSPACE%\${{ matrix.install_prefix }} -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=%QTDIR% -DGDL_UI_GENERATE_TRANSLATIONS=on -GNinja -DCMAKE_C_COMPILER=cl -DCMAKE_CXX_COMPILER=cl -DCMAKE_CXX_FLAGS="-D_WIN32_WINNT=0x0A00"
           cmake --build build --config Release --parallel
           mkdir windows_pdb
           copy /Y build\Release\bin\*.pdb windows_pdb


### PR DESCRIPTION
## Summary
- Pin Windows CI C/C++ compiler to MSVC after vcvarsall setup
- Keep Ninja generator while preventing Git Bash/MinGW c++.exe from being selected

## Verification
- Checked failed run logs: Windows job selected GNU 15.2.0 from C:\mingw64 and failed on MSVC-only /EHsc
- Verified workflow contains CC/CXX and CMake compiler pinning